### PR TITLE
chore: improved StringRecordId class

### DIFF
--- a/src/Cbor/Types/Record/StringRecordId.php
+++ b/src/Cbor/Types/Record/StringRecordId.php
@@ -6,11 +6,16 @@ use Surreal\Cbor\Interfaces\RecordInterface;
 
 final readonly class StringRecordId implements RecordInterface
 {
+    /** @var string $recordId */
     public string $recordId;
 
-    public function __construct(string $recordId)
+    public function __construct(string|StringRecordId|RecordId $recordId)
     {
-        $this->recordId = $recordId;
+        $this->recordId = match(true) {
+            $recordId instanceof StringRecordId => $recordId->toString(),
+            $recordId instanceof RecordId => $recordId->toString(),
+            default => $recordId
+        };
     }
 
     public function __toString(): string
@@ -30,7 +35,7 @@ final readonly class StringRecordId implements RecordInterface
 
     public function equals(StringRecordId $recordId): bool
     {
-        return $this->recordId === $recordId->recordId;
+        return $this->recordId === $recordId->toString();
     }
 
     public static function create(string $recordId): StringRecordId

--- a/tests/core/cbor/StringRecordIdTest.php
+++ b/tests/core/cbor/StringRecordIdTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Beau\CborPHP\exceptions\CborException;
+use PHPUnit\Framework\TestCase;
 use Surreal\Cbor\CBOR;
 use Surreal\Cbor\Types\Record\StringRecordId;
 
-class StringRecordIdTest extends \PHPUnit\Framework\TestCase
+class StringRecordIdTest extends TestCase
 {
     const RECORD_ID_STRING = "record:some-record";
 
@@ -26,5 +27,37 @@ class StringRecordIdTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('"' . self::RECORD_ID_STRING . '"', json_encode($stringRecordId));
 
         $this->assertEquals(self::RECORD_ID_STRING, strval($stringRecordId));
+    }
+
+    public function testInstantiateStringRecordId()
+    {
+        $stringRecordId = new StringRecordId(self::RECORD_ID_STRING);
+        $this->assertEquals(self::RECORD_ID_STRING, $stringRecordId->toString());
+    }
+
+    public function testEquals()
+    {
+        $strid1 = new StringRecordId(self::RECORD_ID_STRING);
+        $strid2 = new StringRecordId(self::RECORD_ID_STRING);
+
+        $this->assertTrue($strid1->equals($strid2));
+
+        $strid3 = new StringRecordId("record:some-other-record-1");
+        $this->assertFalse($strid1->equals($strid3));
+    }
+
+    public function testJSONSerialize()
+    {
+        $strid = new StringRecordId(self::RECORD_ID_STRING);
+        $this->assertEquals('"' . self::RECORD_ID_STRING . '"', json_encode($strid));
+
+        // reparsing the JSON should give the same string
+        $this->assertEquals(self::RECORD_ID_STRING, json_decode(json_encode($strid), true));
+    }
+
+    public function testCreate()
+    {
+        $strid = StringRecordId::create(self::RECORD_ID_STRING);
+        $this->assertEquals(self::RECORD_ID_STRING, $strid->toString());
     }
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

added functionality on top of the StringRecordId class which is essential. Also to keep it streamlined with the JS SDK.

## What does this change do?

StringRecordId class constructor accepts the `StringRecordId` and `RecordId` as an argument rather than only `string`

## What is your testing strategy?

Added unit testing to cover test cases for the `StringRecordId` class

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)