### PR TITLE
fix: issue when using let with http protocol

### DIFF
--- a/src/Core/Traits/SurrealTrait.php
+++ b/src/Core/Traits/SurrealTrait.php
@@ -94,7 +94,7 @@ trait SurrealTrait
      * @param string $value
      * @return null
      */
-    public function let(string $param, string $value): null
+    public function let(string $param, mixed $value): null
     {
         $this->params[$param] = $value;
         return null;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Making sure the `let` function in the `HTTP` engine works as expected

## What does this change do?

The type of the second argument was changed from `string` to `mixed`

## What is your testing strategy?

Added unit test done in an other PR.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)