### PR TITLE
fix: hardcode php version in composer setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     - name: Setup Composer
       uses: php-actions/composer@v6
       continue-on-error: true
+      with:
+        php_version: '8.2'
 
     - name: SurrealDB in Github Actions
       uses: surrealdb/setup-surreal@v2


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fixing the CI github script

## What does this change do?

Hardcode the php version in the composer setup step

## What is your testing strategy?

CI

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)