### PR TITLE
fix: disable phpstan config extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"phpstan/extension-installer": true
+			"phpstan/extension-installer": false
 		}
 	},
 	"extra": {


### PR DESCRIPTION
By disabling the phpstan extension-installer, the users of this package do not get a broken configuration in their projects as phpstan will not try to load a non-existent file.

In the future, the extension should be added and the installer re-enabled.

## What is the motivation?

#18 

## What does this change do?

By disabling the phpstan extension-installer, the users of this package do not get a broken configuration in their projects as phpstan will not try to load a non-existent file.

## What is your testing strategy?

Simply install the package into a project that is already using phpstan.

## Is this related to any issues?

#18 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)