### PR TITLE
fix: disable phpstan config extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,6 @@
 		}
 	},
 	"extra": {
-		"phpstan": {
-			"includes": [
-				"extension.neon"
-			]
-		},
 		"phpstan/extension-installer": {
 			"ignore": [
 				"phpstan/phpstan-phpunit"


### PR DESCRIPTION
By disabling the phpstan extension-installer, the users of this package do not get a broken configuration in their projects as phpstan will not try to load a non-existent file.

## What is the motivation?

When using the SDK within a project that already has phpstan, it immediately breaks as the `extension.neon` file is missing.

## What does this change do?

It removes the configuration that pulls in the non-existing file, therefore fixes the auto-loading configuration for any user.

## What is your testing strategy?

Install the SDK in any project that has phpstan already in use. See how the config no longer breaks.

## Is this related to any issues?

#18 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.php/blob/main/CONTRIBUTING.md)